### PR TITLE
Properly support nuwave/lighthouse ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "nuwave/lighthouse": "^2.6||^3.0||dev-master",
+        "nuwave/lighthouse": "^3.0",
         "laravel/passport": "^7.0"
     },
     "require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-Lighthouse GraphQL Passport Auth (Laravel 5.7+)
+Lighthouse GraphQL Passport Auth (Laravel 5.8 / Lighthouse ^3.2)
 ===============================================
 
 
@@ -6,11 +6,11 @@ Lighthouse GraphQL Passport Auth (Laravel 5.7+)
 [![Total Downloads](https://poser.pugx.org/joselfonseca/lighthouse-graphql-passport-auth/downloads.svg)](https://packagist.org/packages/joselfonseca/lighthouse-graphql-passport-auth)
 [![License](https://poser.pugx.org/laravel/framework/license.svg)](https://packagist.org/packages/laravel/framework)
 
-GraphQL mutations for Laravel Passport using Lighthouse PHP
+GraphQL mutations for Laravel Passport using Lighthouse PHP ^3.2.
 
 ## Installation
 
-**Make sure you have [Laravel Passport](https://laravel.com/docs/5.7/passport) installed.**
+**Make sure you have [Laravel Passport](https://laravel.com/docs/5.8/passport) installed.**
 
 To install run `composer require joselfonseca/lighthouse-graphql-passport-auth`.
 

--- a/src/Providers/LighthouseGraphQLPassportServiceProvider.php
+++ b/src/Providers/LighthouseGraphQLPassportServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Joselfonseca\LighthouseGraphQLPassport\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Nuwave\Lighthouse\Events\BuildingAST;
+use Nuwave\Lighthouse\Events\BuildSchemaString;
 
 /**
  * Class LighthouseGraphQLPassportServiceProvider
@@ -20,8 +20,8 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
         $this->registerConfig();
 
         app('events')->listen(
-            BuildingAST::class,
-            function (BuildingAST $buildingAST): string {
+            BuildSchemaString::class,
+            function (): string {
                 if (config('lighthouse-graphql-passport.schema')) {
                     return file_get_contents(config('lighthouse-graphql-passport.schema'));
                 }

--- a/tests/Integration/GraphQL/Mutations/Logout.php
+++ b/tests/Integration/GraphQL/Mutations/Logout.php
@@ -9,25 +9,15 @@ class Logout extends TestCase
 {
     function test_it_invalidates_token_on_logout()
     {
-        $this->createClient();
-        User::create([
+        $this->artisan('migrate', ['--database' => 'testbench']);
+        $user = User::create([
             'name' => 'Jose Fonseca',
             'email' => 'jose@example.com',
             'password' => bcrypt('123456789qq')
         ]);
-        $response = $this->postGraphQL([
-            'query' => 'mutation {
-                login(data: {
-                    username: "jose@example.com",
-                    password: "123456789qq"
-                }) {
-                    access_token
-                    refresh_token
-                }
-            }'
-        ]);
-        $responseBody = json_decode($response->getContent(), true);
-        $token = $responseBody['data']['login']['access_token'];
+        $this->createClientPersonal($user);
+        $token = $user->createToken('test Token');
+        $token = $token->accessToken;
         $response = $this->postGraphQL([
             'query' => 'mutation {
                 logout {

--- a/tests/Integration/GraphQL/Mutations/RefreshToken.php
+++ b/tests/Integration/GraphQL/Mutations/RefreshToken.php
@@ -38,6 +38,6 @@ class RefreshToken extends TestCase
             }'
         ]);
         $responseBodyRefreshed = json_decode($responseRefreshed->getContent(), true);
-        $this->assertNotEquals($responseBody['data']['login']['access_token'], $responseBodyRefreshed['data']['refreshToken']['access_token']);
+        $this->assertNotEquals($responseBody['data']['login']['access_token'], $responseBodyRefreshed['data']['login']['access_token']);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,15 +1,16 @@
 <?php
+
 namespace Joselfonseca\LighthouseGraphQLPassport\Tests;
 
 use Laravel\Passport\Passport;
 use Laravel\Passport\ClientRepository;
 use Laravel\Passport\PassportServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Nuwave\Lighthouse\Providers\LighthouseServiceProvider;
+use Nuwave\Lighthouse\LighthouseServiceProvider;
+use Joselfonseca\LighthouseGraphQLPassport\Providers\LighthouseGraphQLPassportServiceProvider;
 
 class TestCase extends Orchestra
 {
-
     /**
      * @param \Illuminate\Foundation\Application $app
      * @return array
@@ -20,14 +21,14 @@ class TestCase extends Orchestra
             ServiceProvider::class,
             PassportServiceProvider::class,
             LighthouseServiceProvider::class,
-            \Joselfonseca\LighthouseGraphQLPassport\Providers\LighthouseGraphQLPassportServiceProvider::class
+            LighthouseGraphQLPassportServiceProvider::class,
         ];
     }
 
     /**
      * Define environment setup.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param \Illuminate\Foundation\Application $app
      * @return void
      */
     protected function getEnvironmentSetUp($app)
@@ -36,11 +37,11 @@ class TestCase extends Orchestra
         // Setup default database to use sqlite :memory:
         $app['config']->set('database.default', 'testbench');
         $app['config']->set('database.connections.testbench', [
-            'driver'   => 'sqlite',
+            'driver' => 'sqlite',
             'database' => ':memory:',
-            'prefix'   => '',
+            'prefix' => '',
         ]);
-        $app['config']->set('lighthouse.schema.register', __DIR__.'/schema.graphql');
+        $app['config']->set('lighthouse.schema.register', __DIR__ . '/schema.graphql');
         $app['config']->set('auth.guards', [
             'web' => [
                 'driver' => 'session',
@@ -70,7 +71,7 @@ class TestCase extends Orchestra
     public function createClient()
     {
         $this->artisan('migrate', ['--database' => 'testbench']);
-        Passport::loadKeysFrom(__DIR__.'/storage/');
+        Passport::loadKeysFrom(__DIR__ . '/storage/');
         $client = app(ClientRepository::class)->createPasswordGrantClient(null, 'test', 'http://localhost');
         config()->set('lighthouse-graphql-passport.client_id', $client->id);
         config()->set('lighthouse-graphql-passport.client_secret', $client->secret);
@@ -80,8 +81,8 @@ class TestCase extends Orchestra
     /**
      * Execute a query as if it was sent as a request to the server.
      *
-     * @param  mixed[]  $data
-     * @param  mixed[]  $headers
+     * @param mixed[] $data
+     * @param mixed[] $headers
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
     protected function postGraphQL(array $data, array $headers = [])

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -77,6 +77,17 @@ class TestCase extends Orchestra
         config()->set('lighthouse-graphql-passport.client_secret', $client->secret);
     }
 
+    /**
+     * Create a passport client for testing
+     */
+    public function createClientPersonal($user)
+    {
+        Passport::loadKeysFrom(__DIR__ . '/storage/');
+        $client = app(ClientRepository::class)->createPersonalAccessClient($user->id, 'test', 'http://localhost');
+        config()->set('lighthouse-graphql-passport.client_id', $client->id);
+        config()->set('lighthouse-graphql-passport.client_secret', $client->secret);
+    }
+
 
     /**
      * Execute a query as if it was sent as a request to the server.


### PR DESCRIPTION
Since nuwave/lighthouse version 3, some classes have been moved and renamed. This breaks this package. For example, the schema isn't properly loaded automatically [because the events have been renamed](https://github.com/nuwave/lighthouse/commit/e415d72ffa9c26f0e17716e318240e98197d1cf4#diff-148fd8ecf4a635236717fc042a0a2823). 

This PR fixes that, and fixes composer.json to require nuwave/lighthouse version ^3.0. This breaks for users who are still on nuwave/lighthouse < 3.0 so it may be a wise thing to bump the major version of this package.

I will create another PR fixing the tests once this PR has been merged, so that fix can be based upon this PR.

Thank you for this awesome package!