### PR TITLE
Properly support nuwave/lighthouse ^2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "nuwave/lighthouse": "^2.6||^3.0||dev-master",
+        "nuwave/lighthouse": "^2.6",
         "laravel/passport": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "7.*",
-        "orchestra/testbench": "~3.8"
+        "orchestra/testbench": "~3.7"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-Lighthouse GraphQL Passport Auth (Laravel 5.7+)
+Lighthouse GraphQL Passport Auth (Laravel 5.7 / Lighthouse 2.6)
 ===============================================
 
 
@@ -6,7 +6,7 @@ Lighthouse GraphQL Passport Auth (Laravel 5.7+)
 [![Total Downloads](https://poser.pugx.org/joselfonseca/lighthouse-graphql-passport-auth/downloads.svg)](https://packagist.org/packages/joselfonseca/lighthouse-graphql-passport-auth)
 [![License](https://poser.pugx.org/laravel/framework/license.svg)](https://packagist.org/packages/laravel/framework)
 
-GraphQL mutations for Laravel Passport using Lighthouse PHP
+GraphQL mutations for Laravel Passport using Lighthouse PHP 2.6.x.
 
 ## Installation
 


### PR DESCRIPTION
See https://github.com/joselfonseca/lighthouse-graphql-passport-auth/pull/8 . 

This fixes requirements for nuwave/lighthouse ^2.6. This also breaks Laravel 5.8 support because nuwave/lighthouse ^2.6 does not support Laravel 5.8.

I think you should bump the minor version of this package (1.2.0 or something) so Lighthouse 2.6 users can use this patch, and Lighthouse ^3.0 users can use the major bumped version.