### PR TITLE
Added trigger for Registered event

### DIFF
--- a/src/GraphQL/Mutations/Register.php
+++ b/src/GraphQL/Mutations/Register.php
@@ -3,6 +3,7 @@
 namespace Joselfonseca\LighthouseGraphQLPassport\GraphQL\Mutations;
 
 use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Auth\Events\Registered;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 class Register extends BaseAuthResolver
@@ -29,6 +30,7 @@ class Register extends BaseAuthResolver
         $user = $model->where('email', $args['email'])->first();
         $response = $this->makeRequest($credentials);
         $response['user'] = $user;
+        event(new Registered($user));
         return $response;
     }
 


### PR DESCRIPTION
In order to be more congruent with the default behavior of Laravel, this PR triggers the Registered event that would normally be triggered using the default registration process. 