### PR TITLE
Not be able to get token because the user name is not passed correctly to the Passport.

### DIFF
--- a/src/GraphQL/Mutations/BaseAuthResolver.php
+++ b/src/GraphQL/Mutations/BaseAuthResolver.php
@@ -14,8 +14,8 @@ class BaseAuthResolver
      */
     public function buildCredentials(array $args = [], $grantType = "password")
     {
-        $args = collect($args);
-        $credentials = $args->except('directive')->toArray();
+        $credentials['username'] = $args['input']['username'];
+        $credentials['password'] = $args['input']['password'];
         $credentials['client_id'] = config('lighthouse-graphql-passport.client_id');
         $credentials['client_secret'] = config('lighthouse-graphql-passport.client_secret');
         $credentials['grant_type'] = $grantType;

--- a/src/GraphQL/Mutations/Login.php
+++ b/src/GraphQL/Mutations/Login.php
@@ -20,7 +20,7 @@ class Login extends BaseAuthResolver
         $credentials = $this->buildCredentials($args);
         $response = $this->makeRequest($credentials);
         $model = app(config('auth.providers.users.model'));
-        $user = $model->where(config('lighthouse-graphql-passport.username'), $args['username'])->firstOrFail();
+        $user = $model->where(config('lighthouse-graphql-passport.username'), $args['input']['username'])->firstOrFail();
         $response['user'] = $user;
         return $response;
     }


### PR DESCRIPTION

{
  "errors": [
    {
      "message": "The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.",
      "extensions": {
        "guards": [],
        "category": "authentication"
      },
      ...
   }
}