### PR TITLE
Uses app URL instead of calling localhost

### DIFF
--- a/src/GraphQL/Mutations/BaseAuthResolver.php
+++ b/src/GraphQL/Mutations/BaseAuthResolver.php
@@ -24,7 +24,7 @@ class BaseAuthResolver
 
     public function makeRequest(array $credentials)
     {
-        $request = Request::create('oauth/token', 'POST', $credentials,[], [], [
+        $request = Request::create(url()->to('oauth/token'), 'POST', $credentials,[], [], [
             'HTTP_Accept' => 'application/json'
         ]);
         $response = app()->handle($request);


### PR DESCRIPTION
Instead of calling `http://localhost`, the request should call the app URL. The request failed if you have `https` redirect implemented. I assume it would also fail if you are on a host where `localhost` doesn't lead to this app, but I didn't test that.