### PR TITLE
Get args from input

### DIFF
--- a/src/GraphQL/Mutations/BaseAuthResolver.php
+++ b/src/GraphQL/Mutations/BaseAuthResolver.php
@@ -15,7 +15,7 @@ class BaseAuthResolver
     public function buildCredentials(array $args = [], $grantType = "password")
     {
         $args = collect($args);
-        $credentials = $args->except('directive')->toArray();
+        $credentials = $args->get('input');
         $credentials['client_id'] = config('lighthouse-graphql-passport.client_id');
         $credentials['client_secret'] = config('lighthouse-graphql-passport.client_secret');
         $credentials['grant_type'] = $grantType;
@@ -24,7 +24,7 @@ class BaseAuthResolver
 
     public function makeRequest(array $credentials)
     {
-        $request = Request::create('oauth/token', 'POST', $credentials,[], [], [
+        $request = Request::create('oauth/token', 'POST', $credentials, [], [], [
             'HTTP_Accept' => 'application/json'
         ]);
         $response = app()->handle($request);

--- a/src/GraphQL/Mutations/Login.php
+++ b/src/GraphQL/Mutations/Login.php
@@ -20,9 +20,8 @@ class Login extends BaseAuthResolver
         $credentials = $this->buildCredentials($args);
         $response = $this->makeRequest($credentials);
         $model = app(config('auth.providers.users.model'));
-        $user = $model->where(config('lighthouse-graphql-passport.username'), $args['username'])->firstOrFail();
+        $user = $model->where(config('lighthouse-graphql-passport.username'), $credentials['username'])->firstOrFail();
         $response['user'] = $user;
         return $response;
     }
-
 }


### PR DESCRIPTION
This package seems to be broken (when printing $args received we see input => [ username, password], but the code expects $args = [ username, password]).

It might also be that we're not sending the details properly from the client, but we're not sure:

`
mutation Login($username: String!, $password: String!) {
        login(input: { username: $username, password: $password }) {
          access_token
          refresh_token
          expires_in
          token_type
          user {
            id
            email
            name
          }
        }
}
`