### PR TITLE
Only add avatar if it doesn't already exist

### DIFF
--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -16,7 +16,10 @@ class UpdateSocialProviderUsersTable extends Migration
         Schema::table('users', function (Blueprint $table) {
             $table->string('provider')->nullable();
             $table->string('provider_id')->nullable();
-            $table->string('avatar')->nullable();
+            
+            if (!Schema::hasColumn('users', 'avatar')) {
+                $table->string('avatar')->nullable();
+            }
         });
     }
 


### PR DESCRIPTION
This is an extremely common column name and can cause conflicts.  Should check the column doesn't exist first.