### PR TITLE
Fixed problem that the oauth keys are loaded on boot

### DIFF
--- a/src/Providers/LighthouseGraphQLPassportServiceProvider.php
+++ b/src/Providers/LighthouseGraphQLPassportServiceProvider.php
@@ -5,12 +5,10 @@ namespace Joselfonseca\LighthouseGraphQLPassport\Providers;
 use Illuminate\Support\ServiceProvider;
 use Joselfonseca\LighthouseGraphQLPassport\OAuthGrants\LoggedInGrant;
 use Joselfonseca\LighthouseGraphQLPassport\OAuthGrants\SocialGrant;
-use Laravel\Passport\Bridge\PersonalAccessGrant;
 use Laravel\Passport\Bridge\RefreshTokenRepository;
 use Laravel\Passport\Bridge\UserRepository;
 use Laravel\Passport\Passport;
 use League\OAuth2\Server\AuthorizationServer;
-use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 use Nuwave\Lighthouse\Events\BuildSchemaString;
 
 /**

--- a/src/Providers/LighthouseGraphQLPassportServiceProvider.php
+++ b/src/Providers/LighthouseGraphQLPassportServiceProvider.php
@@ -23,6 +23,16 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        [$publicKey, $privateKey] = [
+            Passport::keyPath('oauth-public.key'),
+            Passport::keyPath('oauth-private.key'),
+        ];
+
+        /** Don't try to boot when you can't load the passport keys. */
+        if (!file_exists($publicKey) || !file_exists($privateKey)) {
+            return;
+        }
+
         if (config('lighthouse-graphql-passport.migrations')) {
             $this->loadMigrationsFrom(__DIR__.'/../../migrations');
         }

--- a/src/Providers/LighthouseGraphQLPassportServiceProvider.php
+++ b/src/Providers/LighthouseGraphQLPassportServiceProvider.php
@@ -81,7 +81,6 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
             $this->app->make(UserRepository::class),
             $this->app->make(RefreshTokenRepository::class)
         );
-
         $grant->setRefreshTokenTTL(Passport::refreshTokensExpireIn());
 
         return $grant;
@@ -98,14 +97,13 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
             $this->app->make(UserRepository::class),
             $this->app->make(RefreshTokenRepository::class)
         );
-
         $grant->setRefreshTokenTTL(Passport::refreshTokensExpireIn());
 
         return $grant;
     }
 
     /**
-     * Register the authorization server.
+     * Register the Grants.
      *
      * @return void
      */

--- a/src/Providers/LighthouseGraphQLPassportServiceProvider.php
+++ b/src/Providers/LighthouseGraphQLPassportServiceProvider.php
@@ -111,8 +111,6 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
     {
         $this->app->extend(AuthorizationServer::class, function ($server) {
             return tap($server, function ($server) {
-                $server->setDefaultScope(Passport::$defaultScope);
-
                 $server->enableGrantType(
                     $this->makeLoggedInRequestGrant(), Passport::tokensExpireIn()
                 );

--- a/src/Providers/LighthouseGraphQLPassportServiceProvider.php
+++ b/src/Providers/LighthouseGraphQLPassportServiceProvider.php
@@ -82,6 +82,8 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
             $this->app->make(RefreshTokenRepository::class)
         );
 
+        $grant->setRefreshTokenTTL(Passport::refreshTokensExpireIn());
+
         return $grant;
     }
 
@@ -96,6 +98,8 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
             $this->app->make(UserRepository::class),
             $this->app->make(RefreshTokenRepository::class)
         );
+
+        $grant->setRefreshTokenTTL(Passport::refreshTokensExpireIn());
 
         return $grant;
     }
@@ -112,11 +116,11 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
                 $server->setDefaultScope(Passport::$defaultScope);
 
                 $server->enableGrantType(
-                    $this->makeLoggedInRequestGrant(), Passport::refreshTokensExpireIn()
+                    $this->makeLoggedInRequestGrant(), Passport::tokensExpireIn()
                 );
 
                 $server->enableGrantType(
-                    $this->makeCustomRequestGrant(), Passport::refreshTokensExpireIn()
+                    $this->makeCustomRequestGrant(), Passport::tokensExpireIn()
                 );
             });
         });


### PR DESCRIPTION
That should not be allowed as then you can't run passport:install. So
with that fix it is possible. You only have one problem when you change
the load path of the oauth keys after you have loaded the ServiceProvider
of this package.


I have fixed it for the default way passport is used, eg you don't change the location of the oauth keys.