### PR TITLE
Issue/find user model by method

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -37,7 +37,9 @@ return [
     |--------------------------------------------------------------------------
     |
     | What column should be use for the username in the users table to find
-    | the user.
+    | the user. Optionally you can add a 'findForPassport' method on your
+    | auth model to have a more fine grain control of the user retrieval.
+    | See https://laravel.com/docs/7.x/passport#customizing-the-username-field
     |
     */
     'username' => 'email',

--- a/src/GraphQL/Mutations/Login.php
+++ b/src/GraphQL/Mutations/Login.php
@@ -3,6 +3,7 @@
 namespace Joselfonseca\LighthouseGraphQLPassport\GraphQL\Mutations;
 
 use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 class Login extends BaseAuthResolver
@@ -20,11 +21,50 @@ class Login extends BaseAuthResolver
     public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo)
     {
         $credentials = $this->buildCredentials($args);
-        $response = $this->makeRequest($credentials);
-        $model = app(config('auth.providers.users.model'));
-        $user = $model->where(config('lighthouse-graphql-passport.username'), $args['username'])->firstOrFail();
-        $response['user'] = $user;
+        $response    = $this->makeRequest($credentials);
+        $user        = $this->findUser($args['username']);
 
-        return $response;
+        $this->validateUser($user);
+
+        return array_merge(
+            $response,
+            [
+                'user' => $user
+            ]
+        );
+    }
+
+    protected function validateUser($user)
+    {
+        $authModelClass = $this->getAuthModelClass();
+        if ($user instanceof $authModelClass && $user->exists) {
+            return;
+        }
+
+        throw (new ModelNotFoundException())->setModel(
+            get_class($this->makeAuthModelInstance())
+        );
+    }
+
+    protected function getAuthModelClass(): string
+    {
+        return config('auth.providers.users.model');
+    }
+
+    protected function makeAuthModelInstance()
+    {
+        $modelClass = $this->getAuthModelClass();
+        return new $modelClass;
+    }
+
+    protected function findUser(string $username)
+    {
+        $model = $this->makeAuthModelInstance();
+
+        if (method_exists($model, 'findForPassport')) {
+            return $model->findForPassport($username);
+        }
+
+        return $model->where(config('lighthouse-graphql-passport.username'), $username)->first();
     }
 }

--- a/src/GraphQL/Mutations/Login.php
+++ b/src/GraphQL/Mutations/Login.php
@@ -21,15 +21,15 @@ class Login extends BaseAuthResolver
     public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo)
     {
         $credentials = $this->buildCredentials($args);
-        $response    = $this->makeRequest($credentials);
-        $user        = $this->findUser($args['username']);
+        $response = $this->makeRequest($credentials);
+        $user = $this->findUser($args['username']);
 
         $this->validateUser($user);
 
         return array_merge(
             $response,
             [
-                'user' => $user
+                'user' => $user,
             ]
         );
     }
@@ -54,7 +54,8 @@ class Login extends BaseAuthResolver
     protected function makeAuthModelInstance()
     {
         $modelClass = $this->getAuthModelClass();
-        return new $modelClass;
+
+        return new $modelClass();
     }
 
     protected function findUser(string $username)

--- a/tests/Admin.php
+++ b/tests/Admin.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Joselfonseca\LighthouseGraphQLPassport\Tests;
-
 
 class Admin extends User
 {

--- a/tests/Admin.php
+++ b/tests/Admin.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Joselfonseca\LighthouseGraphQLPassport\Tests;
+
+
+class Admin extends User
+{
+    protected $table = 'users';
+
+    public function findForPassport($username)
+    {
+        return self::query()
+            ->where('name', $username)
+            ->first();
+    }
+}

--- a/tests/Integration/GraphQL/Mutations/ForgotPassword.php
+++ b/tests/Integration/GraphQL/Mutations/ForgotPassword.php
@@ -15,11 +15,7 @@ class ForgotPassword extends TestCase
         Mail::fake();
         Notification::fake();
         $this->createClient();
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => bcrypt('123456789qq'),
-        ]);
+        $user = factory(User::class)->create();
         $response = $this->postGraphQL([
             'query' => 'mutation {
                 forgotPassword(input: {

--- a/tests/Integration/GraphQL/Mutations/LoginTest.php
+++ b/tests/Integration/GraphQL/Mutations/LoginTest.php
@@ -2,25 +2,56 @@
 
 namespace Joselfonseca\LighthouseGraphQLPassport\Tests\Integration\GraphQL\Mutations;
 
+use Illuminate\Support\Facades\Hash;
+use Joselfonseca\LighthouseGraphQLPassport\Tests\Admin;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\TestCase;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 
 class LoginTest extends TestCase
 {
-    public function test_it_gets_access_token()
+    use MakesGraphQLRequests;
+
+    public function dataProvider(): array
     {
+        return [
+            'default'                    => [
+                User::class,
+                [
+                    'username' => 'jose@example.com',
+                    'password' => '123456789qq'
+                ]
+            ],
+            'findForPassport' => [
+                Admin::class,
+                [
+                    'username' => 'Jose Fonseca',
+                    'password' => '123456789qq'
+                ],
+                true
+
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function test_it_gets_access_token(string $modelClass, array $credentials, bool $hasFindForPassportMethod = false)
+    {
+        $this->app['config']->set('auth.providers.users.model', $modelClass);
+
         $this->createClient();
-        User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => bcrypt('123456789qq'),
-        ]);
-        $response = $this->postGraphQL([
-            'query' => 'mutation {
-                login(input: {
-                    username: "jose@example.com",
-                    password: "123456789qq"
-                }) {
+
+        factory($modelClass)->create();
+
+        if ($hasFindForPassportMethod) {
+            self::assertTrue(method_exists($modelClass, 'findForPassport'));
+        }
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+            mutation Login($input: LoginInput) {
+                login(input: $input) {
                     access_token
                     refresh_token
                     user {
@@ -29,15 +60,25 @@ class LoginTest extends TestCase
                         email
                     }
                 }
-            }',
+            }
+        ',
+            [
+                'input' => $credentials
+            ]
+        );
+
+        $response->assertJsonStructure([
+            'data' => [
+                'login' => [
+                    'access_token',
+                    'refresh_token',
+                    'user' => [
+                        'id',
+                        'name',
+                        'email',
+                    ]
+                ],
+            ]
         ]);
-        $responseBody = json_decode($response->getContent(), true);
-        $this->assertArrayHasKey('login', $responseBody['data']);
-        $this->assertArrayHasKey('access_token', $responseBody['data']['login']);
-        $this->assertArrayHasKey('refresh_token', $responseBody['data']['login']);
-        $this->assertArrayHasKey('user', $responseBody['data']['login']);
-        $this->assertArrayHasKey('id', $responseBody['data']['login']['user']);
-        $this->assertArrayHasKey('name', $responseBody['data']['login']['user']);
-        $this->assertArrayHasKey('email', $responseBody['data']['login']['user']);
     }
 }

--- a/tests/Integration/GraphQL/Mutations/LoginTest.php
+++ b/tests/Integration/GraphQL/Mutations/LoginTest.php
@@ -2,7 +2,6 @@
 
 namespace Joselfonseca\LighthouseGraphQLPassport\Tests\Integration\GraphQL\Mutations;
 
-use Illuminate\Support\Facades\Hash;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\Admin;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\TestCase;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
@@ -19,18 +18,18 @@ class LoginTest extends TestCase
                 User::class,
                 [
                     'username' => 'jose@example.com',
-                    'password' => '123456789qq'
-                ]
+                    'password' => '123456789qq',
+                ],
             ],
             'findForPassport' => [
                 Admin::class,
                 [
                     'username' => 'Jose Fonseca',
-                    'password' => '123456789qq'
+                    'password' => '123456789qq',
                 ],
-                true
+                true,
 
-            ]
+            ],
         ];
     }
 
@@ -63,7 +62,7 @@ class LoginTest extends TestCase
             }
         ',
             [
-                'input' => $credentials
+                'input' => $credentials,
             ]
         );
 
@@ -76,9 +75,9 @@ class LoginTest extends TestCase
                         'id',
                         'name',
                         'email',
-                    ]
+                    ],
                 ],
-            ]
+            ],
         ]);
     }
 }

--- a/tests/Integration/GraphQL/Mutations/Logout.php
+++ b/tests/Integration/GraphQL/Mutations/Logout.php
@@ -10,11 +10,7 @@ class Logout extends TestCase
     public function test_it_invalidates_token_on_logout()
     {
         $this->artisan('migrate', ['--database' => 'testbench']);
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => bcrypt('123456789qq'),
-        ]);
+        $user = factory(User::class)->create();
         $this->createClientPersonal($user);
         $token = $user->createToken('test Token');
         $token = $token->accessToken;

--- a/tests/Integration/GraphQL/Mutations/RefreshToken.php
+++ b/tests/Integration/GraphQL/Mutations/RefreshToken.php
@@ -10,11 +10,7 @@ class RefreshToken extends TestCase
     public function test_it_refresh_a_token()
     {
         $this->createClient();
-        User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => bcrypt('123456789qq'),
-        ]);
+        factory(User::class)->create();
         $response = $this->postGraphQL([
             'query' => 'mutation {
                 login(input: {

--- a/tests/Integration/GraphQL/Mutations/ResetPassword.php
+++ b/tests/Integration/GraphQL/Mutations/ResetPassword.php
@@ -15,11 +15,7 @@ class ResetPassword extends TestCase
     public function test_it_resets_a_password_for_user(): void
     {
         $this->createClient();
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => Hash::make('123456789qq'),
-        ]);
+        $user = factory(User::class)->create();
 
         $token = Password::createToken($user);
 

--- a/tests/Integration/GraphQL/Mutations/UpdatePasswordTest.php
+++ b/tests/Integration/GraphQL/Mutations/UpdatePasswordTest.php
@@ -3,7 +3,6 @@
 namespace Joselfonseca\LighthouseGraphQLPassport\Tests\Integration\GraphQL\Mutations;
 
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Hash;
 use Joselfonseca\LighthouseGraphQLPassport\Events\PasswordUpdated;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\TestCase;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\User;

--- a/tests/Integration/GraphQL/Mutations/UpdatePasswordTest.php
+++ b/tests/Integration/GraphQL/Mutations/UpdatePasswordTest.php
@@ -15,11 +15,7 @@ class UpdatePasswordTest extends TestCase
     {
         Event::fake([PasswordUpdated::class]);
         $this->createClient();
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => Hash::make('123456789qq'),
-        ]);
+        $user = factory(User::class)->create();
         Passport::actingAs($user);
         $response = $this->postGraphQL([
             'query' => 'mutation {
@@ -45,11 +41,7 @@ class UpdatePasswordTest extends TestCase
     {
         Event::fake([PasswordUpdated::class]);
         $this->createClient();
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => bcrypt('123456789qq'),
-        ]);
+        $user = factory(User::class)->create();
         Passport::actingAs($user);
         $response = $this->postGraphQL([
             'query' => 'mutation {
@@ -71,11 +63,7 @@ class UpdatePasswordTest extends TestCase
     {
         Event::fake([PasswordUpdated::class]);
         $this->createClient();
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => bcrypt('123456789qq'),
-        ]);
+        factory(User::class)->create();
         $response = $this->postGraphQL([
             'query' => 'mutation {
                 updatePassword(input: {
@@ -97,11 +85,7 @@ class UpdatePasswordTest extends TestCase
     {
         Event::fake([PasswordUpdated::class]);
         $this->createClient();
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => Hash::make('123456789qq'),
-        ]);
+        $user = factory(User::class)->create();
         Passport::actingAs($user);
         $response = $this->postGraphQL([
             'query' => 'mutation {

--- a/tests/Integration/Http/Middleware/AuthenticateWithApiGuard.php
+++ b/tests/Integration/Http/Middleware/AuthenticateWithApiGuard.php
@@ -10,11 +10,7 @@ class AuthenticateWithApiGuard extends TestCase
     public function test_it_sets_user_via_global_middleware()
     {
         $this->createClient();
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => bcrypt('123456789qq'),
-        ]);
+        $user = factory(User::class)->create();
         $response = $this->postGraphQL([
             'query' => 'mutation {
                 login(input: {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,12 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withFactories(__DIR__ . '/factories');
+    }
+
     /**
      * @param \Illuminate\Foundation\Application $app
      *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,7 @@ class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
-        $this->withFactories(__DIR__ . '/factories');
+        $this->withFactories(__DIR__.'/factories');
     }
 
     /**

--- a/tests/Unit/HasLoggedInTokens.php
+++ b/tests/Unit/HasLoggedInTokens.php
@@ -10,11 +10,7 @@ class HasLoggedInTokens extends TestCase
     public function test_it_gets_passport_tokens()
     {
         $this->createClient();
-        $user = User::create([
-            'name'     => 'Jose Fonseca',
-            'email'    => 'jose@example.com',
-            'password' => bcrypt('123456789qq'),
-        ]);
+        $user = factory(User::class)->create();
         $this->actingAs($user);
         $tokens = $user->getTokens();
         $this->assertArrayHasKey('access_token', $tokens);

--- a/tests/factories/AdminFactory.php
+++ b/tests/factories/AdminFactory.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Hash;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\Admin;
 
 app(Factory::class)->define(Admin::class, function (Faker $faker) {
-
     static $password;
 
     if (!$password) {

--- a/tests/factories/AdminFactory.php
+++ b/tests/factories/AdminFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Support\Facades\Hash;
+use Joselfonseca\LighthouseGraphQLPassport\Tests\Admin;
+
+app(Factory::class)->define(Admin::class, function (Faker $faker) {
+
+    static $password;
+
+    if (!$password) {
+        $password = Hash::make('123456789qq');
+    }
+
+    return [
+        'name'     => 'Jose Fonseca',
+        'email'    => 'jose@example.com',
+        'password' => $password,
+    ];
+});

--- a/tests/factories/UserFactory.php
+++ b/tests/factories/UserFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Support\Facades\Hash;
+use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
+
+app(Factory::class)->define(User::class, function (Faker $faker) {
+
+    static $password;
+
+    if (!$password) {
+        $password = Hash::make('123456789qq');
+    }
+
+    return [
+        'name'     => 'Jose Fonseca',
+        'email'    => 'jose@example.com',
+        'password' => $password,
+    ];
+});

--- a/tests/factories/UserFactory.php
+++ b/tests/factories/UserFactory.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Hash;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
 
 app(Factory::class)->define(User::class, function (Faker $faker) {
-
     static $password;
 
     if (!$password) {


### PR DESCRIPTION
First of all, thanks for this awesome package.

I am using it for the first time on a current project and ran into a limitation.\
I wanted to give the users the ability to login with either email or username.

Since the package is tightly coupled to laravel passport, I was wondering why not to optionally use the `findForPassport` method on the auth model to have more control of the retrieval of the user instance: https://laravel.com/docs/7.x/passport#customizing-the-username-field

Since the new feature does not introduce a breaking change, I am still a bit concerned if this addition might have side effects for existing codebases.

Looking forward to your feedback!

Best,\
Peter

Additional changes I made to the codebase
* Updated some assertion methods
* Used the provided graphql test traits from laravel lighthouse package
* Replaced test user creation with factories