### PR TITLE
Improve extendability of Register Mutation

### DIFF
--- a/src/GraphQL/Mutations/Register.php
+++ b/src/GraphQL/Mutations/Register.php
@@ -52,7 +52,7 @@ class Register extends BaseAuthResolver
         ];
     }
 
-    private function validateAuthModel($model): void
+    protected function validateAuthModel($model): void
     {
         $authModelClass = $this->getAuthModelFactory()->getClass();
 


### PR DESCRIPTION
The `validateAuthModel` is private and restricts extensions somewhat.