### PR TITLE
Extract token from verificationUrl in VerifyEmail

### DIFF
--- a/src/Notifications/VerifyEmail.php
+++ b/src/Notifications/VerifyEmail.php
@@ -15,12 +15,24 @@ class VerifyEmail extends \Illuminate\Auth\Notifications\VerifyEmail
      */
     protected function verificationUrl($notifiable)
     {
-        $payload = base64_encode(json_encode([
+        $payload = $this->getToken($notifiable);
+
+        return config('lighthouse-graphql-passport.verify_email.base_url').'?token='.$payload;
+    }
+
+    /**
+     * Get a token for the given notifiable.
+     *
+     * @param mixed $notifiable
+     *
+     * @return string
+     */
+    protected function getToken($notifiable)
+    {
+        return base64_encode(json_encode([
             'id'         => $notifiable->getKey(),
             'hash'       => encrypt($notifiable->getEmailForVerification()),
             'expiration' => encrypt(Carbon::now()->addMinutes(10)->toIso8601String()),
         ]));
-
-        return config('lighthouse-graphql-passport.verify_email.base_url').'?token='.$payload;
     }
 }


### PR DESCRIPTION
In order to more easily extend the `VerifyEmail` notification, I've extracted the logic for generating the token to a separate method. This way you can replace the logic for generating the url or generating the token separately without touching the other.