### PR TITLE
Fix 122

### DIFF
--- a/src/GraphQL/Mutations/BaseAuthResolver.php
+++ b/src/GraphQL/Mutations/BaseAuthResolver.php
@@ -57,4 +57,17 @@ class BaseAuthResolver
     {
         return app(AuthModelFactory::class);
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function makeAuthModelInstance()
+    {
+        return $this->getAuthModelFactory()->make();
+    }
+
+    protected function getAuthModelClass(): string
+    {
+        return $this->getAuthModelFactory()->getClass();
+    }
 }

--- a/src/GraphQL/Mutations/Login.php
+++ b/src/GraphQL/Mutations/Login.php
@@ -48,16 +48,6 @@ class Login extends BaseAuthResolver
             ->setModel($authModelClass);
     }
 
-    protected function getAuthModelClass(): string
-    {
-        return $this->getAuthModelFactory()->getClass();
-    }
-
-    protected function makeAuthModelInstance()
-    {
-        return $this->getAuthModelFactory()->make();
-    }
-
     protected function findUser(string $username)
     {
         $model = $this->makeAuthModelInstance();

--- a/src/GraphQL/Mutations/RefreshToken.php
+++ b/src/GraphQL/Mutations/RefreshToken.php
@@ -45,14 +45,6 @@ class RefreshToken extends BaseAuthResolver
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Model
-     */
-    protected function makeAuthModelInstance()
-    {
-        return $this->getAuthModelFactory()->make();
-    }
-
-    /**
      * @param $accessToken
      *
      * @return false|mixed

--- a/src/GraphQL/Mutations/SocialLogin.php
+++ b/src/GraphQL/Mutations/SocialLogin.php
@@ -25,7 +25,7 @@ class SocialLogin extends BaseAuthResolver
     {
         $credentials = $this->buildCredentials($args, 'social_grant');
         $response = $this->makeRequest($credentials);
-        $model = app(config('auth.providers.users.model'));
+        $model = $this->makeAuthModelInstance();
         $user = $model->where('id', Auth::user()->id)->firstOrFail();
         $response['user'] = $user;
 

--- a/src/GraphQL/Mutations/VerifyEmail.php
+++ b/src/GraphQL/Mutations/VerifyEmail.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Joselfonseca\LighthouseGraphQLPassport\Exceptions\ValidationException;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
-class VerifyEmail
+class VerifyEmail  extends BaseAuthResolver
 {
     /**
      * @param $rootValue
@@ -32,7 +32,7 @@ class VerifyEmail
                 'token' => __('The token is invalid'),
             ], 'Validation Error');
         }
-        $model = app(config('auth.providers.users.model'));
+        $model = $this->makeAuthModelInstance();
 
         try {
             $user = $model->where('email', $email)->firstOrFail();

--- a/src/GraphQL/Mutations/VerifyEmail.php
+++ b/src/GraphQL/Mutations/VerifyEmail.php
@@ -12,9 +12,8 @@ use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 /**
  * Class VerifyEmail
- * @package Joselfonseca\LighthouseGraphQLPassport\GraphQL\Mutations
  */
-class VerifyEmail  extends BaseAuthResolver
+class VerifyEmail extends BaseAuthResolver
 {
     /**
      * @param $rootValue

--- a/src/GraphQL/Mutations/VerifyEmail.php
+++ b/src/GraphQL/Mutations/VerifyEmail.php
@@ -10,6 +10,10 @@ use Illuminate\Support\Facades\Auth;
 use Joselfonseca\LighthouseGraphQLPassport\Exceptions\ValidationException;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
+/**
+ * Class VerifyEmail
+ * @package Joselfonseca\LighthouseGraphQLPassport\GraphQL\Mutations
+ */
 class VerifyEmail  extends BaseAuthResolver
 {
     /**

--- a/src/GraphQL/Mutations/VerifyEmail.php
+++ b/src/GraphQL/Mutations/VerifyEmail.php
@@ -11,7 +11,7 @@ use Joselfonseca\LighthouseGraphQLPassport\Exceptions\ValidationException;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 /**
- * Class VerifyEmail
+ * Class VerifyEmail.
  */
 class VerifyEmail extends BaseAuthResolver
 {


### PR DESCRIPTION
- Use `makeAuthModelInstance` in all resolvers where is needed

Fix #122 