### PR TITLE
Refactor Social Login

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,18 @@
+<?php
+
+use PhpCsFixer\Finder;
+
+$project_path = getcwd();
+$finder = Finder::create()
+    ->in([
+        $project_path . '/config',
+        $project_path . '/migrations',
+        $project_path . '/src',
+        $project_path . '/tests',
+    ])
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return \ShiftCS\styles($finder);

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,3 @@
+risky: false
+version: 7
+preset: laravel

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "orchestra/testbench": "^5.0|^6.0"
+        "orchestra/testbench": "^5.0|^6.0",
+        "eduarguz/shift-php-cs": "dev-master"
     },
     "autoload": {
         "psr-4": {
@@ -44,5 +45,10 @@
                 "Joselfonseca\\LighthouseGraphQLPassport\\Providers\\LighthouseGraphQLPassportServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "cs": [
+            "PHP_CS_FIXER_IGNORE_ENV=true vendor/bin/php-cs-fixer fix --config=.php_cs.dist -vvv --using-cache=no"
+        ]
     }
 }

--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -14,7 +14,7 @@ class UpdateSocialProviderUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            if (!Schema::hasColumn('users', 'avatar')) {
+            if (! Schema::hasColumn('users', 'avatar')) {
                 $table->string('avatar')->nullable();
             }
         });

--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -14,12 +14,16 @@ class UpdateSocialProviderUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('provider')->nullable();
-            $table->string('provider_id')->nullable();
-
             if (!Schema::hasColumn('users', 'avatar')) {
                 $table->string('avatar')->nullable();
             }
+        });
+        Schema::create('social_providers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('provider')->index();
+            $table->string('provider_id')->index();
+            $table->timestamps();
         });
     }
 
@@ -31,9 +35,8 @@ class UpdateSocialProviderUsersTable extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('provider');
-            $table->dropColumn('provider_id');
             $table->dropColumn('avatar');
         });
+        Schema::dropIfExists('social_providers');
     }
 }

--- a/src/GraphQL/Mutations/Logout.php
+++ b/src/GraphQL/Mutations/Logout.php
@@ -22,7 +22,7 @@ class Logout extends BaseAuthResolver
      */
     public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo)
     {
-        if (!Auth::guard('api')->check()) {
+        if (! Auth::guard('api')->check()) {
             throw new AuthenticationException('Not Authenticated', 'Not Authenticated');
         }
         $user = Auth::guard('api')->user();

--- a/src/GraphQL/Mutations/UpdatePassword.php
+++ b/src/GraphQL/Mutations/UpdatePassword.php
@@ -24,7 +24,7 @@ class UpdatePassword
     public function resolve($rootValue, array $args, GraphQLContext $context = null, ResolveInfo $resolveInfo)
     {
         $user = $context->user();
-        if (!Hash::check($args['old_password'], $user->password)) {
+        if (! Hash::check($args['old_password'], $user->password)) {
             throw new ValidationException([
                 'password' => __('Current password is incorrect'),
             ], 'Validation Exception');

--- a/src/HasSocialLogin.php
+++ b/src/HasSocialLogin.php
@@ -15,7 +15,6 @@ use Laravel\Socialite\Facades\Socialite;
  */
 trait HasSocialLogin
 {
-
     public function socialProviders()
     {
         return $this->hasMany(SocialProvider::class);

--- a/src/Models/SocialProvider.php
+++ b/src/Models/SocialProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace Joselfonseca\LighthouseGraphQLPassport\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Joselfonseca\LighthouseGraphQLPassport\Contracts\AuthModelFactory;
+
+class SocialProvider extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'provider',
+        'provider_id',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo($this->getAuthModelFactory()->getClass());
+    }
+
+    protected function getAuthModelFactory(): AuthModelFactory
+    {
+        return app(AuthModelFactory::class);
+    }
+}

--- a/src/Models/SocialProvider.php
+++ b/src/Models/SocialProvider.php
@@ -7,7 +7,6 @@ use Joselfonseca\LighthouseGraphQLPassport\Contracts\AuthModelFactory;
 
 class SocialProvider extends Model
 {
-
     protected $fillable = [
         'user_id',
         'provider',

--- a/src/Models/SocialProvider.php
+++ b/src/Models/SocialProvider.php
@@ -1,15 +1,12 @@
 <?php
 
-
 namespace Joselfonseca\LighthouseGraphQLPassport\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Joselfonseca\LighthouseGraphQLPassport\Contracts\AuthModelFactory;
 
 class SocialProvider extends Model
 {
-    use HasFactory;
 
     protected $fillable = [
         'user_id',

--- a/tests/Integration/GraphQL/Mutations/Login.php
+++ b/tests/Integration/GraphQL/Mutations/Login.php
@@ -52,7 +52,7 @@ class Login extends TestCase
             self::assertTrue(method_exists($modelClass, 'findForPassport'));
         }
 
-        $response = $this->graphQL(/** @lang GraphQL */ '
+        $response = $this->graphQL(/* @lang GraphQL */ '
             mutation Login($input: LoginInput) {
                 login(input: $input) {
                     access_token
@@ -106,7 +106,7 @@ class Login extends TestCase
             self::assertTrue(method_exists($modelClass, 'findForPassport'));
         }
 
-        $response = $this->graphQL(/** @lang GraphQL */ '
+        $response = $this->graphQL(/* @lang GraphQL */ '
             mutation Login($input: LoginInput) {
                 login(input: $input) {
                     access_token
@@ -161,7 +161,7 @@ class Login extends TestCase
             self::assertTrue(method_exists($modelClass, 'findForPassport'));
         }
 
-        $response = $this->graphQL(/** @lang GraphQL */ '
+        $response = $this->graphQL(/* @lang GraphQL */ '
             mutation Login($input: LoginInput) {
                 login(input: $input) {
                     access_token

--- a/tests/Integration/GraphQL/Mutations/Login.php
+++ b/tests/Integration/GraphQL/Mutations/Login.php
@@ -9,7 +9,7 @@ use Joselfonseca\LighthouseGraphQLPassport\Tests\TestCase;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 
-class LoginTest extends TestCase
+class Login extends TestCase
 {
     use MakesGraphQLRequests;
 

--- a/tests/Integration/GraphQL/Mutations/SocialLogin.php
+++ b/tests/Integration/GraphQL/Mutations/SocialLogin.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Joselfonseca\LighthouseGraphQLPassport\Tests\Integration\GraphQL\Mutations;
+
+use Joselfonseca\LighthouseGraphQLPassport\Models\SocialProvider;
+use Joselfonseca\LighthouseGraphQLPassport\Tests\TestCase;
+use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
+use Laravel\Socialite\Facades\Socialite;
+use Mockery;
+use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
+
+class SocialLogin extends TestCase
+{
+
+    use MakesGraphQLRequests;
+
+    public function mockSocialite(SocialProvider $provider)
+    {
+        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
+        $abstractUser
+            ->shouldReceive('getId')
+            ->andReturn($provider->provider_id)
+            ->shouldReceive('getName')
+            ->andReturn($provider->user->name)
+            ->shouldReceive('getEmail')
+            ->andReturn($provider->user->email);
+        Socialite::shouldReceive('driver->userFromToken')->andReturn($abstractUser);
+    }
+
+    public function mockSocialiteWithoutUser()
+    {
+        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
+        $abstractUser
+            ->shouldReceive('getId')
+            ->andReturn('fakeId')
+            ->shouldReceive('getName')
+            ->andReturn('Jose Fonseca')
+            ->shouldReceive('getEmail')
+            ->andReturn('jose@example.com');
+        Socialite::shouldReceive('driver->userFromToken')->andReturn($abstractUser);
+    }
+
+    public function mockSocialiteWithUser(User $user)
+    {
+        $abstractUser = Mockery::mock('Laravel\Socialite\Two\User');
+        $abstractUser
+            ->shouldReceive('getId')
+            ->andReturn('fakeId')
+            ->shouldReceive('getName')
+            ->andReturn('Jose Fonseca')
+            ->shouldReceive('getEmail')
+            ->andReturn($user->email);
+        Socialite::shouldReceive('driver->userFromToken')->andReturn($abstractUser);
+    }
+
+    public function test_it_generates_tokens_with_social_grant_for_existing_user()
+    {
+        $this->createClient();
+        $provider = factory(SocialProvider::class)->create();
+        $this->mockSocialite($provider);
+        $response = $this->graphQL(/** @lang GraphQL */ '
+            mutation socialLogin($input: SocialLoginInput!) {
+                socialLogin(input: $input) {
+                    access_token
+                    refresh_token
+                    user {
+                        id
+                        name
+                        email
+                    }
+                }
+            }
+        ',
+            [
+                'input' => [
+                    'provider' => 'github',
+                    'token' => 'some-valid-token-from-github'
+                ],
+            ]
+        );
+        $decodedResponse = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('access_token', $decodedResponse['data']['socialLogin']);
+        $this->assertArrayHasKey('refresh_token', $decodedResponse['data']['socialLogin']);
+    }
+
+    public function test_it_generates_tokens_with_social_grant_for_non_existing_user()
+    {
+        $this->createClient();
+        $this->mockSocialiteWithoutUser();
+        $response = $this->graphQL(/** @lang GraphQL */ '
+            mutation socialLogin($input: SocialLoginInput!) {
+                socialLogin(input: $input) {
+                    access_token
+                    refresh_token
+                    user {
+                        id
+                        name
+                        email
+                    }
+                }
+            }
+        ',
+            [
+                'input' => [
+                    'provider' => 'github',
+                    'token' => 'some-valid-token-from-github'
+                ],
+            ]
+        );
+        $decodedResponse = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('access_token', $decodedResponse['data']['socialLogin']);
+        $this->assertArrayHasKey('refresh_token', $decodedResponse['data']['socialLogin']);
+        $this->assertDatabaseHas('users', [
+            'email' => 'jose@example.com',
+            'name' => 'Jose Fonseca',
+        ]);
+        $createdUser = User::first();
+        $this->assertDatabaseHas('social_providers', [
+            'user_id' => $createdUser->id,
+            'provider' => 'github',
+            'provider_id' => 'fakeId',
+        ]);
+    }
+
+    public function test_it_generates_tokens_with_social_grant_for_existing_user_without_social_provider()
+    {
+        $this->createClient();
+        $user = factory(User::class)->create();
+        $this->mockSocialiteWithUser($user);
+        $this->assertDatabaseMissing('social_providers', [
+            'user_id' => $user->id,
+        ]);
+        $response = $this->graphQL(/** @lang GraphQL */ '
+            mutation socialLogin($input: SocialLoginInput!) {
+                socialLogin(input: $input) {
+                    access_token
+                    refresh_token
+                    user {
+                        id
+                        name
+                        email
+                    }
+                }
+            }
+        ',
+            [
+                'input' => [
+                    'provider' => 'github',
+                    'token' => 'some-valid-token-from-github'
+                ],
+            ]
+        );
+        $decodedResponse = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('access_token', $decodedResponse['data']['socialLogin']);
+        $this->assertArrayHasKey('refresh_token', $decodedResponse['data']['socialLogin']);
+        $this->assertDatabaseHas('social_providers', [
+            'user_id' => $user->id,
+            'provider' => 'github',
+            'provider_id' => 'fakeId',
+        ]);
+    }
+
+}

--- a/tests/Integration/GraphQL/Mutations/SocialLogin.php
+++ b/tests/Integration/GraphQL/Mutations/SocialLogin.php
@@ -11,7 +11,6 @@ use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 
 class SocialLogin extends TestCase
 {
-
     use MakesGraphQLRequests;
 
     public function mockSocialite(SocialProvider $provider)
@@ -58,7 +57,7 @@ class SocialLogin extends TestCase
         $this->createClient();
         $provider = factory(SocialProvider::class)->create();
         $this->mockSocialite($provider);
-        $response = $this->graphQL(/** @lang GraphQL */ '
+        $response = $this->graphQL(/* @lang GraphQL */ '
             mutation socialLogin($input: SocialLoginInput!) {
                 socialLogin(input: $input) {
                     access_token
@@ -74,7 +73,7 @@ class SocialLogin extends TestCase
             [
                 'input' => [
                     'provider' => 'github',
-                    'token' => 'some-valid-token-from-github'
+                    'token' => 'some-valid-token-from-github',
                 ],
             ]
         );
@@ -87,7 +86,7 @@ class SocialLogin extends TestCase
     {
         $this->createClient();
         $this->mockSocialiteWithoutUser();
-        $response = $this->graphQL(/** @lang GraphQL */ '
+        $response = $this->graphQL(/* @lang GraphQL */ '
             mutation socialLogin($input: SocialLoginInput!) {
                 socialLogin(input: $input) {
                     access_token
@@ -103,7 +102,7 @@ class SocialLogin extends TestCase
             [
                 'input' => [
                     'provider' => 'github',
-                    'token' => 'some-valid-token-from-github'
+                    'token' => 'some-valid-token-from-github',
                 ],
             ]
         );
@@ -130,7 +129,7 @@ class SocialLogin extends TestCase
         $this->assertDatabaseMissing('social_providers', [
             'user_id' => $user->id,
         ]);
-        $response = $this->graphQL(/** @lang GraphQL */ '
+        $response = $this->graphQL(/* @lang GraphQL */ '
             mutation socialLogin($input: SocialLoginInput!) {
                 socialLogin(input: $input) {
                     access_token
@@ -146,7 +145,7 @@ class SocialLogin extends TestCase
             [
                 'input' => [
                     'provider' => 'github',
-                    'token' => 'some-valid-token-from-github'
+                    'token' => 'some-valid-token-from-github',
                 ],
             ]
         );
@@ -159,5 +158,4 @@ class SocialLogin extends TestCase
             'provider_id' => 'fakeId',
         ]);
     }
-
 }

--- a/tests/Integration/GraphQL/Mutations/UpdatePassword.php
+++ b/tests/Integration/GraphQL/Mutations/UpdatePassword.php
@@ -8,7 +8,7 @@ use Joselfonseca\LighthouseGraphQLPassport\Tests\TestCase;
 use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
 use Laravel\Passport\Passport;
 
-class UpdatePasswordTest extends TestCase
+class UpdatePassword extends TestCase
 {
     public function test_it_updates_logged_in_user_password()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,8 +4,8 @@ namespace Joselfonseca\LighthouseGraphQLPassport\Tests;
 
 use Joselfonseca\LighthouseGraphQLPassport\Providers\LighthouseGraphQLPassportServiceProvider;
 use Laravel\Passport\ClientRepository;
-use Laravel\Passport\Passport;
 use Laravel\Passport\PassportServiceProvider;
+use Laravel\Socialite\SocialiteServiceProvider;
 use Nuwave\Lighthouse\LighthouseServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
@@ -27,6 +27,7 @@ class TestCase extends Orchestra
         return [
             ServiceProvider::class,
             PassportServiceProvider::class,
+            SocialiteServiceProvider::class,
             LighthouseServiceProvider::class,
             LighthouseGraphQLPassportServiceProvider::class,
         ];

--- a/tests/User.php
+++ b/tests/User.php
@@ -5,6 +5,7 @@ namespace Joselfonseca\LighthouseGraphQLPassport\Tests;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Joselfonseca\LighthouseGraphQLPassport\HasLoggedInTokens;
+use Joselfonseca\LighthouseGraphQLPassport\HasSocialLogin;
 use Laravel\Passport\HasApiTokens;
 
 /**
@@ -15,6 +16,7 @@ class User extends Authenticatable
     use HasApiTokens;
     use Notifiable;
     use HasLoggedInTokens;
+    use HasSocialLogin;
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/factories/AdminFactory.php
+++ b/tests/factories/AdminFactory.php
@@ -8,7 +8,7 @@ use Joselfonseca\LighthouseGraphQLPassport\Tests\Admin;
 app(Factory::class)->define(Admin::class, function (Faker $faker) {
     static $password;
 
-    if (!$password) {
+    if (! $password) {
         $password = Hash::make('123456789qq');
     }
 

--- a/tests/factories/SocialProviderFactory.php
+++ b/tests/factories/SocialProviderFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factory;
+use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
+
+app(Factory::class)->define(\Joselfonseca\LighthouseGraphQLPassport\Models\SocialProvider::class, function (Faker $faker) {
+    return [
+        'user_id' => factory(User::class)->create()->id,
+        'provider' => 'github',
+        'provider_id' => 'fakeId'
+    ];
+});

--- a/tests/factories/SocialProviderFactory.php
+++ b/tests/factories/SocialProviderFactory.php
@@ -8,6 +8,6 @@ app(Factory::class)->define(\Joselfonseca\LighthouseGraphQLPassport\Models\Socia
     return [
         'user_id' => factory(User::class)->create()->id,
         'provider' => 'github',
-        'provider_id' => 'fakeId'
+        'provider_id' => 'fakeId',
     ];
 });

--- a/tests/factories/UserFactory.php
+++ b/tests/factories/UserFactory.php
@@ -8,7 +8,7 @@ use Joselfonseca\LighthouseGraphQLPassport\Tests\User;
 app(Factory::class)->define(User::class, function (Faker $faker) {
     static $password;
 
-    if (!$password) {
+    if (! $password) {
         $password = Hash::make('123456789qq');
     }
 


### PR DESCRIPTION
- Refactor how social login works
- Add tests
- Support multiple social providers

**Breaking change:** The migration now creates a different table to hold the providers information instead of using the users table. Please be careful when upgrading an API that uses the socialite integration.

Fix #98 