### PR TITLE
Update BaseAuthResolver.php to gracefully handle errors without an "error" key

### DIFF
--- a/src/GraphQL/Mutations/BaseAuthResolver.php
+++ b/src/GraphQL/Mutations/BaseAuthResolver.php
@@ -47,7 +47,7 @@ class BaseAuthResolver
                 throw new AuthenticationException(__('Authentication exception'), __('Incorrect username or password'));
             }
 
-            throw new AuthenticationException(__($decodedResponse['error']), __($decodedResponse['message']));
+            throw new AuthenticationException(__($decodedResponse['error'] ?? ''), __($decodedResponse['message']));
         }
 
         return $decodedResponse;


### PR DESCRIPTION
Currently, when a json response without an "error" key is returned by the app, graphql throws an error with:

```json
"debugMessage": "Undefined array key \"error\"",
"message": "Internal server error",
```

This change would more gracefully handle a wider range of app errors that sometimes have a "message" key and not an "error" key (for example, when the app can't connect to the database).