### PR TITLE
Update 2019_11_19_000000_update_social_provider_users_table.php

### DIFF
--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -20,7 +20,7 @@ class UpdateSocialProviderUsersTable extends Migration
         });
         Schema::create('social_providers', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('user_id');
+            $table->unsignedBigInteger('user_id');
             $table->string('provider')->index();
             $table->string('provider_id')->index();
             $table->timestamps();


### PR DESCRIPTION
changed user_id type to avoid 

(errno: 150 "Foreign key constraint is incorrectly formed") (SQL: alter table `social_providers` add constraint `social
_providers_user_id_foreign` foreign key (`user_id`) references `users` (`id`) on delete cascade)
