### PR TITLE
Enforce referential integrity at the database level

### DIFF
--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -20,11 +20,10 @@ class UpdateSocialProviderUsersTable extends Migration
         });
         Schema::create('social_providers', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('user_id');
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
             $table->string('provider')->index();
             $table->string('provider_id')->index();
             $table->timestamps();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 


### PR DESCRIPTION
The default laravel 8 user id  `$table->id();` type does not match `$table->unsignedBigInteger('user_id');` and this migration fails on fresh laravel 8 installs.

reference: https://laravel.com/docs/7.x/migrations#foreign-key-constraints