### PR TITLE
Move legacy factories to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         "nuwave/lighthouse": "^4.17 || ^5.0",
         "laravel/passport": "^9.0 || ^10.0",
         "laravel/socialite": "^4.0 || ^5.0",
-        "laravel/legacy-factories": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^9.0",
         "orchestra/testbench": "^4 || ^5 || ^6",
-        "eduarguz/shift-php-cs": "dev-master"
+        "eduarguz/shift-php-cs": "dev-master",
+        "laravel/legacy-factories": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.3.0",
         "nuwave/lighthouse": "^4.17 || ^5.0",
         "laravel/passport": "^9.0 || ^10.0",
-        "laravel/socialite": "^4.0 || ^5.0",
+        "laravel/socialite": "^4.0 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^9.0",


### PR DESCRIPTION
I think laravel/legacy-factories is only needed by the tests, so it can be moved to the require-dev section 😃 