### PR TITLE
Fix for migration error

### DIFF
--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -22,13 +22,8 @@ class UpdateSocialProviderUsersTable extends Migration
             $table->bigIncrements('id');
             $table->string('provider')->index();
             $table->string('provider_id')->index();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');;
             $table->timestamps();
-        });
-
-        // Fix for migration error:
-        /*  SQLSTATE[42000]: Syntax error or access violation: 1072 Key column 'user_id' doesn't exist in table (SQL: alter table `social_providers` add constraint `social_providers_user_id_foreign` foreign key (`user_id`) references `users` (`id`) on delete cascade) */
-        Schema::table('social_providers', function (Blueprint $table) {
-            $table->foreignId('user_id')->after('provider_id')->constrained()->onDelete('cascade');;
         });
     }
 

--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -13,7 +13,7 @@ class UpdateSocialProviderUsersTable extends Migration
      */
     public function up()
     {
-        if (!Schema::hasTable('users')) {
+        if (! Schema::hasTable('users')) {
             Schema::create('users', function (Blueprint $table) {
                 $table->id();
                 $table->string('avatar')->nullable();

--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -22,7 +22,7 @@ class UpdateSocialProviderUsersTable extends Migration
             $table->bigIncrements('id');
             $table->string('provider')->index();
             $table->string('provider_id')->index();
-            $table->foreignId('user_id')->constrained()->onDelete('cascade');;
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -13,7 +13,7 @@ class UpdateSocialProviderUsersTable extends Migration
      */
     public function up()
     {
-         if (!Schema::hasTable('users')) {
+        if (!Schema::hasTable('users')) {
             Schema::create('users', function (Blueprint $table) {
                 $table->id();
                 $table->string('avatar')->nullable();

--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -13,16 +13,31 @@ class UpdateSocialProviderUsersTable extends Migration
      */
     public function up()
     {
-        Schema::table('users', function (Blueprint $table) {
-            if (! Schema::hasColumn('users', 'avatar')) {
+         if (!Schema::hasTable('users')) {
+            Schema::create('users', function (Blueprint $table) {
+                $table->id();
                 $table->string('avatar')->nullable();
-            }
-        });
+                $table->string('name');
+                $table->string('email')->unique();
+                $table->timestamp('email_verified_at')->nullable();
+                $table->string('password');
+                $table->rememberToken();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table('users', function (Blueprint $table) {
+                if (! Schema::hasColumn('users', 'avatar')) {
+                    $table->string('avatar')->nullable();
+                }
+            });
+        }
+
         Schema::create('social_providers', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
             $table->string('provider')->index();
             $table->string('provider_id')->index();
-            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/migrations/2019_11_19_000000_update_social_provider_users_table.php
+++ b/migrations/2019_11_19_000000_update_social_provider_users_table.php
@@ -20,11 +20,15 @@ class UpdateSocialProviderUsersTable extends Migration
         });
         Schema::create('social_providers', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('user_id');
             $table->string('provider')->index();
             $table->string('provider_id')->index();
             $table->timestamps();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+
+        // Fix for migration error:
+        /*  SQLSTATE[42000]: Syntax error or access violation: 1072 Key column 'user_id' doesn't exist in table (SQL: alter table `social_providers` add constraint `social_providers_user_id_foreign` foreign key (`user_id`) references `users` (`id`) on delete cascade) */
+        Schema::table('social_providers', function (Blueprint $table) {
+            $table->foreignId('user_id')->after('provider_id')->constrained()->onDelete('cascade');;
         });
     }
 


### PR DESCRIPTION
SQLSTATE[42000]: Syntax error or access violation: 1072 Key column 'user_id' doesn't exist in table (SQL: alter table `social_providers` add constraint `social_providers_user_id_foreign` foreign key (`user_id`) references `users` (`id`) on delete cascade) 