### PR TITLE
Make using custom email verification configurable

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -62,6 +62,7 @@ return [
     |
     */
     'verify_email' => [
+        'use_custom_implementation' => env('LIGHTHOUSE_GRAPHQL_PASSPORT_USE_CUSTOM_EMAIL_VERIFICATION', false),
         'base_url' => env('FRONT_URL').'/email-verify',
     ],
     /*

--- a/src/GraphQL/Mutations/Register.php
+++ b/src/GraphQL/Mutations/Register.php
@@ -27,7 +27,9 @@ class Register extends BaseAuthResolver
         $this->validateAuthModel($model);
 
         if ($model instanceof MustVerifyEmail) {
-            $model->sendEmailVerificationNotification();
+            if (config('lighthouse-graphql-passport.verify_email.use_custom_implementation') === false) {
+                $model->sendEmailVerificationNotification();
+            }
 
             event(new Registered($model));
 


### PR DESCRIPTION
This PR adds the ability to implement your own custom email verification.

The checks fail because of #166 