### PR TITLE
Fix RefreshToken mutation by limiting lcobucci/jwt to ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": ">=8.0",
         "nuwave/lighthouse": "^6.0",
         "laravel/passport": "^9.0 || ^10.0 || ^11.0",
-        "laravel/socialite": "^4.0 || ^5.0"
+        "laravel/socialite": "^4.0 || ^5.0",
+        "lcobucci/jwt": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 || ^10.0",


### PR DESCRIPTION
1. `laravel/passport:^11.0` requires `lcobucci/jwt:^4.3|^5.0`
    https://github.com/laravel/passport/releases/tag/v11.8.5

2. `lcobucci/jwt:^5.0` removed `Lcobucci\JWT\Configuration::forUnsecuredSigner()`
    https://lcobucci-jwt.readthedocs.io/en/latest/upgrading/#removal-of-none-algorithm

This broke the `RefreshToken` mutation, so I've limited the dependency for now as a quick fix. Ideally the method call should be replaced, but I don't have the knowledge or time to do this.