### PR TITLE
Add full support for Laravel Passport 12

### DIFF
--- a/src/GraphQL/Mutations/RefreshToken.php
+++ b/src/GraphQL/Mutations/RefreshToken.php
@@ -5,6 +5,8 @@ namespace Joselfonseca\LighthouseGraphQLPassport\GraphQL\Mutations;
 use GraphQL\Type\Definition\ResolveInfo;
 use Joselfonseca\LighthouseGraphQLPassport\Events\UserRefreshedToken;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Blake2b;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 /**
@@ -47,7 +49,10 @@ class RefreshToken extends BaseAuthResolver
     {
         // since we are generating the token in an internal request, there
         // is no need to verify signature to extract the sub claim
-        $config = Configuration::forUnsecuredSigner();
+        $config = Configuration::forSymmetricSigner(
+            new Blake2b(),
+            InMemory::plainText('refresh-token')
+        );
 
         $token = $config->parser()->parse((string) $accessToken);
 

--- a/src/Providers/LighthouseGraphQLPassportServiceProvider.php
+++ b/src/Providers/LighthouseGraphQLPassportServiceProvider.php
@@ -26,6 +26,9 @@ class LighthouseGraphQLPassportServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if (method_exists(Passport::class, 'enablePasswordGrant')) {
+            Passport::enablePasswordGrant();
+        }
         if (config('lighthouse-graphql-passport.migrations')) {
             $this->loadMigrationsFrom(__DIR__.'/../../migrations');
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -78,6 +78,7 @@ class TestCase extends Orchestra
      */
     public function createClient()
     {
+        $this->artisan('vendor:publish --tag=passport-migrations');
         $this->artisan('migrate');
         $client = app(ClientRepository::class)->createPasswordGrantClient(null, 'test', 'http://localhost');
         config()->set('lighthouse-graphql-passport.client_id', $client->id);


### PR DESCRIPTION
I combined #172 and #171. 

I use the fork of #172 in production since 2 months and it works fine. This PR should fix the missing tests.