### PR TITLE
Fixed RefreshToken mutation

### DIFF
--- a/src/GraphQL/Mutations/RefreshToken.php
+++ b/src/GraphQL/Mutations/RefreshToken.php
@@ -5,6 +5,8 @@ namespace Joselfonseca\LighthouseGraphQLPassport\GraphQL\Mutations;
 use GraphQL\Type\Definition\ResolveInfo;
 use Joselfonseca\LighthouseGraphQLPassport\Events\UserRefreshedToken;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Blake2b;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 /**
@@ -47,7 +49,15 @@ class RefreshToken extends BaseAuthResolver
     {
         // since we are generating the token in an internal request, there
         // is no need to verify signature to extract the sub claim
-        $config = Configuration::forUnsecuredSigner();
+        $appKey = explode(':', config('app.key'));
+
+        if(!isset($appKey[1]))
+            return false;
+
+        $config = Configuration::forSymmetricSigner(
+            new Blake2b(),
+            InMemory::base64Encoded($appKey[1])
+        );
 
         $token = $config->parser()->parse((string) $accessToken);
 


### PR DESCRIPTION
This pull request fixes the RefreshToken mutation returning `Call to undefined method Lcobucci\\JWT\\Configuration::forUnsecuredSigner()`
on Lcobucci\\JWT: "5.0" `Configuration::forUnsecuredSigner()` is removed 
so I followed the steps on their documentation to upgrade to the latest version 
[( upgrade steps )](https://lcobucci-jwt.readthedocs.io/en/stable/upgrading/#removal-of-none-algorithm)
